### PR TITLE
Update for Blender 2.80

### DIFF
--- a/io_scene_brg/__init__.py
+++ b/io_scene_brg/__init__.py
@@ -20,8 +20,8 @@ bl_info = {
     "name": "Age of Mythology Model",
     "description": "Import/Export .brg model files for the game Age of Mythology",
     "author": "Matthijs 'MrEmjeR' de Rijk <mrtherich@gmail.com>",
-    "version": (0, 2, 0),
-    "blender": (2, 7, 5),
+    "version": (0, 3, 0),
+    "blender": (2, 80, 0),
     "warning": "",
     "location": "File > Import-Export",
     "wiki_url": "https://github.com/MrTheRich/AoM-Blender-Addon/wiki",
@@ -40,6 +40,8 @@ from bpy.props import *
 from bpy_extras.io_utils import ExportHelper, ImportHelper
 from bpy.types import Operator, AddonPreferences
 from bpy.props import StringProperty, IntProperty, BoolProperty
+
+
 
 # addon preferences in blender user preferences
 class AoMPreferences(AddonPreferences):
@@ -98,7 +100,7 @@ class IMPORT_BRG(bpy.types.Operator, ImportHelper):
             )
 
     def execute(self, context):
-        preferences = context.user_preferences
+        preferences = context.preferences
         addon_prefs = preferences.addons[__name__].preferences
         importer = brg_import.BRGImporter(context, self, addon_prefs)
 
@@ -189,17 +191,26 @@ def menu_func_import(self, context):
 def menu_func_export(self, context):
     self.layout.operator(EXPORT_BRG.bl_idname, text="Age of Mythology (.brg)")
 
+
+__to_be_registered = [
+    AoMPreferences,
+    IMPORT_BRG,
+    EXPORT_BRG
+]
+
 def register():
-    bpy.utils.register_module(__name__)
+    for cls in __to_be_registered:
+        bpy.utils.register_class(cls)
     reload_scripts()
     os.system('cls') # clear the cmd, temponary for debug
-    bpy.types.INFO_MT_file_import.append(menu_func_import)
-    bpy.types.INFO_MT_file_export.append(menu_func_export)
+    bpy.types.TOPBAR_MT_file_import.append(menu_func_import)
+    bpy.types.TOPBAR_MT_file_export.append(menu_func_export)
 
 def unregister():
-    bpy.utils.unregister_module(__name__)
-    bpy.types.INFO_MT_file_import.remove(menu_func_import)
-    bpy.types.INFO_MT_file_export.remove(menu_func_export)
+    for cls in __to_be_registered:
+        bpy.utils.unregister_class(cls)
+    bpy.types.TOPBAR_MT_file_import.remove(menu_func_import)
+    bpy.types.TOPBAR_MT_file_export.remove(menu_func_export)
 
 def reload_scripts(): # reload all subscripts when reloading main script
     reload(brg_util)

--- a/io_scene_brg/brg_import.py
+++ b/io_scene_brg/brg_import.py
@@ -282,6 +282,7 @@ class BRGImporter:
 
         if hasattr(self, 'frames'):
             bpy.ops.pose.select_all(action='SELECT')
+            bpy.ops.object.mode_set(mode='OBJECT')
             bpy.ops.anim.keyframe_insert(type='LocRotScale')
         bpy.ops.object.mode_set(mode='OBJECT')
 

--- a/io_scene_brg/brg_import.py
+++ b/io_scene_brg/brg_import.py
@@ -22,10 +22,10 @@ class BRGImporter:
         # create a basic mesh object
         self.mesh = bpy.data.meshes.new(self.file.nice_name)
         self.model = bpy.data.objects.new(self.file.nice_name, self.mesh)
-        bpy.context.scene.objects.link(self.model)
-        self.model.select = True
-        bpy.context.scene.objects.active = self.model
-        self.model.location = bpy.context.scene.cursor_location #Needs preference
+        bpy.context.scene.collection.objects.link(self.model)
+        self.model.select_set(True)
+        bpy.context.view_layer.objects.active = self.model
+        self.model.location = bpy.context.scene.cursor.location # Needs preference
         bpy.ops.object.mode_set(mode='OBJECT')
 
 
@@ -34,8 +34,8 @@ class BRGImporter:
         '''close file reading and round up scene'''
         self.file.close()
         # Select the imported objects
-        self.model.select = True
-        bpy.context.scene.objects.active = self.model
+        self.model.select_set(True)
+        bpy.context.view_layer.objects.active = self.model
         if hasattr(self, "frames"):
             bpy.ops.object.shape_key_retime()
 
@@ -133,12 +133,12 @@ class BRGImporter:
             mesh.from_pydata(
                  [(0.0,0.0,0.0) for x in range(self.num_vertices)],
                  [], [(0,0,0) for x in range(self.num_faces)])
-            mesh.uv_textures.new("UVMap")
+            mesh.uv_layers.new(name="UVMap")
             print(mesh.shape_keys)
             # if this is an animation, add shapekey
             if hasattr(self, 'frames'):
                 for frame in range(1,self.frames+1):
-                    model.shape_key_add(str(frame))
+                    model.shape_key_add(name=str(frame))
 
                 mesh.shape_keys.animation_data_create()
                 action = bpy.data.actions.new(name="Shapekey Driver")
@@ -184,7 +184,8 @@ class BRGImporter:
                 face.vertices = file.read_face()
 
             # update the mesh data for uv loops.
-            mesh.update(calc_edges=True, calc_tessface=True)
+            mesh.update(calc_edges=True)
+            mesh.calc_loop_triangles()
             uv_loops = mesh.uv_layers[-1].data
             for loop in mesh.loops:
                 uv_loops[loop.index].uv = uvs[loop.vertex_index]
@@ -193,7 +194,8 @@ class BRGImporter:
                 vertmats = [file.read_short() for v in vertices]
 
         # update mesh data in memory
-        mesh.update(calc_edges=True, calc_tessface=True)
+        mesh.update(calc_edges=True)
+        mesh.calc_loop_triangles()
 
         file.skip(24)
         check_space = file.read_uint() # Unkown but important flag for edge cases
@@ -218,7 +220,7 @@ class BRGImporter:
         if self.props.has(MeshFlags.ATTACHPOINTS):
             self.read_attachpoints()
 
-        bpy.context.scene.objects.active = model
+        bpy.context.view_layer.objects.active = model
         #optional extra space in some edge cases, meaning unsure
         if not check_space and len_space > 0:
             anim_time_adujst = [file.read_float() for i in range(len_space)]
@@ -260,7 +262,7 @@ class BRGImporter:
             for bone in self.armature.pose.bones:
                 bone.custom_shape = shape
 
-        bpy.context.scene.objects.active = self.armature
+        bpy.context.view_layer.objects.active = self.armature
 
         # Read armature matrix data
         xs = [file.read_vec3() for i in range(self.num_matrix)]
@@ -337,7 +339,7 @@ class BRGImporter:
             node_texture.location = -300,350
 
             links = node_tree.links
-            link = links.new(node_texture.outputs[0], node_tree.nodes.get("Diffuse BSDF").inputs[0])
+            link = links.new(node_texture.outputs[0], node_tree.nodes.get("Principled BSDF").inputs[0])
 
         # optional sfx data
         if self.props.has(MatrFlags.SFX):

--- a/io_scene_brg/brg_util.py
+++ b/io_scene_brg/brg_util.py
@@ -224,16 +224,15 @@ def custome_shape():
     # set the material index for the sides
     for x,m in enumerate([0,0,1,1,2,2]):
         cus_obj.data.polygons[x].material_index = m
-    cus_obj.data.update(calc_edges=True, calc_tessface=True)
+    cus_obj.data.update(calc_edges=True)
+    mesh.calc_loop_triangles()
     cus_obj.use_fake_user = True
-    mesh.show_double_sided = True
 
     #create three materials for each axis
-    for i,c in enumerate([(1,0,0),(0,1,0),(0,0,1)]):
+    for i,c in enumerate([(1,0,0,1),(0,1,0,1),(0,0,1,1)]):
         mat = bpy.data.materials.new("_custom_shape." + str(i))
         mat.use_nodes = True
         mat.diffuse_color = c
-        mat.diffuse_intensity = 1.0
         mat.specular_color = (0,0,0)
         cus_obj.data.materials.append(mat)
 


### PR DESCRIPTION
Not sure if `mesh.calc_loop_triangles()` is needed, [but the API change docs seem to imply it is the replacement for calc_tessfaces](https://wiki.blender.org/wiki/Reference/Release_Notes/2.80/Python_API/Mesh_API) and it's better to be safe than sorry.

I didn't test whether automatic texture import works. UV maps get set correctly though, and materials get created properly too. Behold:

![aom_blender](https://user-images.githubusercontent.com/308818/79057026-ed66e380-7c5c-11ea-8b6c-4a29175a2fac.png)

Animations work fine too.